### PR TITLE
Add CodeQL jobs to GitHub Actions workflow

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,24 @@
+name: Schedule
+
+on:
+  schedule:
+    - cron: "00 10 * * 5" # every friday 19:00 JST
+
+jobs:
+  codeql:
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      security-events: write
+    uses: route06/actions/.github/workflows/codeql_core.yml@b4926a2cc01811c7908ded0a7d93f4b5527079d4 # v2.4.0
+    with:
+      language: "javascript"
+  pushover:
+    name: pushover if failure
+    if: github.ref_name == github.event.repository.default_branch && failure()
+    needs: codeql
+    uses: ./.github/workflows/pushover.yml
+    secrets:
+      PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}
+      PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,17 @@ jobs:
         filter_mode: nofilter
         level: error
         reporter: github-pr-review
+  codeql:
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      security-events: write
+    uses: route06/actions/.github/workflows/codeql.yml@b4926a2cc01811c7908ded0a7d93f4b5527079d4 # v2.4.0
   pushover:
     name: pushover if failure
     if: github.ref_name == github.event.repository.default_branch && failure()
-    needs: [actionlint]
+    needs: [actionlint, codeql]
     uses: ./.github/workflows/pushover.yml
     secrets:
       PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}


### PR DESCRIPTION
Since it is always slow to run CodeQL tests, optimize the timing of execution using [route06/actions](https://github.com/route06/actions).

* Run CodeQL only when necessary
* Run CodeQL every Friday
    * Since default CodeQL is also executed on a scheduled basis
