### PR TITLE
Improve .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,10 @@ updates:
       timezone: "Asia/Tokyo"
   - package-ecosystem: "npm"
     directories:
-      - "/github"
-      - "/hatebu"
+      - "/github/notifier"
+      - "/github/subscriber"
+      - "/hatebu/notifier"
+      - "/hatebu/subscriber"
     schedule:
       interval: "monthly"
       time: "19:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,9 @@ updates:
       time: "19:00"
       timezone: "Asia/Tokyo"
   - package-ecosystem: "npm"
-    directory: "/github"
-    schedule:
-      interval: "monthly"
-      time: "19:00"
-      timezone: "Asia/Tokyo"
-    ignore:
-      - dependency-name: "@types/node" # To match the Node.js version in .tool-versions
-  - package-ecosystem: "npm"
-    directory: "/hatebu"
+    directories:
+      - "/github"
+      - "/hatebu"
     schedule:
       interval: "monthly"
       time: "19:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
       timezone: "Asia/Tokyo"
     ignore:
       - dependency-name: "@types/node" # To match the Node.js version in .tool-versions
+    groups:
+      # Combine updates to the same package into a single PR
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## PR Type

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 639fac8915ec1769c76f6a1cc7ce53f47ada0da5

['Enhancement']

## PR Description

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 639fac8915ec1769c76f6a1cc7ce53f47ada0da5

- Dependabotの設定を複数ディレクトリ対応に改善
- 同一パッケージの更新を1つのPRにまとめる設定を追加
- npmエコシステムの監視対象ディレクトリを統合


## PR Walkthrough

<!-- Do not change this section. -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Dependabot設定の統合とPRグループ化</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>複数のnpmディレクトリ設定を1つに統合<br> <li> <code>directories</code>配列で4つのパスを指定<br> <li> <code>groups</code>設定で同一パッケージ更新をPR統合<br> <li> <code>@types/node</code>の無視設定を維持</ul>


</details>


  </td>
  <td><a href="https://github.com/masutaka/masutaka-feed/pull/94/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

#### Testing

<!-- Briefly describe the testing steps or results. -->

### Other Information

<!-- Add any other relevant information for the reviewer. -->