### PR TITLE
Fix deploy error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ REQUIRED_ENVS := GH_FEED_URL GH_TITLE_IGNORE_REGEXP GH_TITLE_PUSHOVER_REGEXP \
 validate-envs:
 	@missing_envs=""; \
 	for env in $(REQUIRED_ENVS); do \
-		if [ -z "$${!env}" ]; then \
+		eval "value=\$$$$env"; \
+		if [ -z "$$value" ]; then \
 			missing_envs="$$missing_envs $$env"; \
 		fi; \
 	done; \


### PR DESCRIPTION
## Related Issue

<!-- Mention the related issue number if applicable. -->

PR https://github.com/masutaka/masutaka-feed/pull/119 の修正。

- https://github.com/masutaka/masutaka-feed/actions/runs/16411545423/job/46367507524

> Run make deploy
> /bin/sh: 3: Bad substitution
> make: *** [Makefile:52: validate-envs] Error 2
> Error: Process completed with exit code 2.

## PR Type

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at a2dd95983e2b35850296c36fe1f6cf5475a821f0

['Bug fix']

## PR Description

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at a2dd95983e2b35850296c36fe1f6cf5475a821f0

- Makefileの環境変数検証ロジックを修正
- 間接参照構文の互換性問題を解決


## PR Walkthrough

<!-- Do not change this section. -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>環境変数検証の間接参照構文を修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- 環境変数の間接参照構文を`${!env}`から`eval`を使用した形式に変更
- シェルの互換性問題を解決してデプロイエラーを修正


</details>


  </td>
  <td><a href="https://github.com/masutaka/masutaka-feed/pull/120/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

#### Testing

<!-- Briefly describe the testing steps or results. -->

### Other Information

<!-- Add any other relevant information for the reviewer. -->