### PR TITLE
security: URL substring sanitization の脆弱性を修正

### DIFF
--- a/github/notifier/index.ts
+++ b/github/notifier/index.ts
@@ -35,9 +35,9 @@ export const handler = async (
   const { entryTitle, entryUrl } = event;
 
   // ワークアラウンド: 相対パスの場合は完全なURLに変換
-  const processedUrl = entryUrl.startsWith('https://github.com')
-    ? entryUrl
-    : `https://github.com${entryUrl}`;
+  const processedUrl = entryUrl.startsWith('/')
+    ? `https://github.com${entryUrl}`
+    : entryUrl;
 
   if (processedUrl !== entryUrl) {
     console.warn(`[Workaround] Converted relative path to full URL: ${processedUrl}`);


### PR DESCRIPTION
## PR Type

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 4f6525b1771d96a29cdccf469897de6b19297eac

['Bug fix']

## PR Description

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 4f6525b1771d96a29cdccf469897de6b19297eac

- URL処理ロジックの脆弱性を修正
- 相対パス判定条件を改善
- セキュリティホールを閉塞


## PR Walkthrough

<!-- Do not change this section. -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>URL処理の脆弱性修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

github/notifier/index.ts

<ul><li>URL処理の判定条件を<code>startsWith('https://github.com')</code>から<code>startsWith('/')</code>に変更<br> <li> 相対パス検出ロジックを改善してセキュリティホールを修正<br> <li> URL変換処理の条件分岐を逆転</ul>


</details>


  </td>
  <td><a href="https://github.com/masutaka/masutaka-feed/pull/134/files#diff-5362fedffde2cdea52a12c9bc19f6d3689f1ad58f04e019347aaf5b9c0a7d2a8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

#### Testing

<!-- Briefly describe the testing steps or results. -->

### Other Information

<!-- Add any other relevant information for the reviewer. -->