### PR TITLE
Notifier 失敗時に通知がロストする問題を解消する

### DIFF
--- a/github/notifier/index.ts
+++ b/github/notifier/index.ts
@@ -61,17 +61,15 @@ const processEntry = async (title: string, url: string): Promise<void> => {
 
   const message = buildMessage(title, url);
 
-  try {
-    const [mastodonResponse, pushoverResponse] = await Promise.all([
-      postToMastodon(`[GH] ${title} ${message}`),
-      sendPushover(title, message)
-    ]);
+  const mastodonResponse = await postToMastodon(`[GH] ${title} ${message}`);
+  console.info('Successfully posted to Mastodon:', mastodonResponse);
 
-    console.info('Successfully posted to Mastodon:', mastodonResponse);
+  // Pushover は best effort（失敗してもエントリーは処理済みとする）
+  try {
+    const pushoverResponse = await sendPushover(title, message);
     console.info('Successfully sent to Pushover:', pushoverResponse);
   } catch (error) {
-    console.error('Failed to process entry:', error);
-    throw error;
+    console.warn('Pushover failed (best effort); ignoring:', error);
   }
 };
 

--- a/github/subscriber/index.ts
+++ b/github/subscriber/index.ts
@@ -91,11 +91,15 @@ const processNewEntry = async (
   };
 
   try {
-    await lambdaClient.send(new InvokeCommand({
+    const response = await lambdaClient.send(new InvokeCommand({
       FunctionName: targetFunctionArn,
       InvocationType: 'RequestResponse',
       Payload: Buffer.from(JSON.stringify(payload))
     }));
+
+    if (response.FunctionError) {
+      throw new Error(`Notifier failed: ${response.FunctionError}`);
+    }
 
     await markAsProcessed(entryId, item, tableName);
     console.info(`Successfully processed entry: ${entryId}`);

--- a/hatebu/subscriber/index.ts
+++ b/hatebu/subscriber/index.ts
@@ -100,11 +100,15 @@ const processNewEntry = async (
   };
 
   try {
-    await lambdaClient.send(new InvokeCommand({
+    const response = await lambdaClient.send(new InvokeCommand({
       FunctionName: targetFunctionArn,
       InvocationType: 'RequestResponse',
       Payload: Buffer.from(JSON.stringify(payload))
     }));
+
+    if (response.FunctionError) {
+      throw new Error(`Notifier failed: ${response.FunctionError}`);
+    }
 
     await markAsProcessed(entryId, item, tableName);
     console.info(`Successfully processed entry: ${entryId}`);


### PR DESCRIPTION
## 概要

Notifier Lambda が throw しても Subscriber Lambda が成功扱いとなり、通知がロストして次回再送もされないバグを修正する。

## 背景

AWS SDK v3 の `@aws-sdk/client-lambda` は `InvocationType: 'RequestResponse'` で呼び出された Lambda が unhandled exception を投げても、クライアント側では throw しない。代わりにレスポンスの `FunctionError` フィールドに `'Unhandled'` を設定するだけ。

現状のコードはこれを見ていなかったため、Notifier が Mastodon 送信失敗で throw しても Subscriber 側は成功扱いで `markAsProcessed` を呼び、次回再送されなかった。

## 変更点

- Subscriber: `InvokeCommand` のレスポンスから `FunctionError` をチェックし、truthy なら throw する
- GitHub Notifier: `Promise.all` をやめ、Mastodon を先に await（主通知）→ Pushover は `try/catch` で warn のみの best effort に変更。Pushover 失敗時の Mastodon 重複投稿を回避
- Hatebu Notifier: 単一送信先のため現状維持

## 再送保証の範囲

| Lambda | エラー時の挙動 |
|---|---|
| Subscriber (GitHub/Hatebu) | 全エラーを次回フォロー |
| GitHub Notifier - Mastodon | 次回フォロー |
| GitHub Notifier - Pushover | best effort。フォローしない（仕様） |
| Hatebu Notifier - Mastodon | 次回フォロー |

## 確認

- `make lint` 通過済み