### PR TITLE
pre-installed 化された SAM CLI に切り替える

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,10 +31,6 @@ jobs:
           aws-region: ap-northeast-1
           role-duration-seconds: 900
           role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
-      - name: Setup SAM CLI
-        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
-        with:
-          use-installer: true
       - run: make deploy
         env:
           GH_FEED_URL: ${{ secrets.GH_FEED_URL }}


### PR DESCRIPTION
## 概要

GitHub Actions の deploy workflow から `aws-actions/setup-sam` の step を削除する。

## 背景

AWS SAM CLI は [2020-04 の actions/runner-images#615](https://github.com/actions/runner-images/pull/615) 以来 Ubuntu runner image に pre-installed されており（現在は [Ubuntu 24.04 runner に AWS SAM CLI 1.157.1](https://github.com/actions/runner-images/blob/a8a3c8258504963ec70a688d16079d5c43622410/images/ubuntu/Ubuntu2404-Readme.md?plain=1#L106)）、本リポジトリで `aws-actions/setup-sam` は長年冗長だった（バージョン pinning もしていない）。

副次的効果として、`aws-actions/setup-sam@v2` の Node.js 20 deprecation 警告（[aws-actions/setup-sam#128](https://github.com/aws-actions/setup-sam/issues/128)）も解消される。

## 変更点

- `.github/workflows/deploy.yml` から `Setup SAM CLI` step を削除

## 確認

- deploy workflow の成功を確認済み