### PR TITLE
tsconfig の TypeScript 6.0 互換化と周辺クリーンアップ

### DIFF
--- a/github/notifier/Makefile
+++ b/github/notifier/Makefile
@@ -3,7 +3,7 @@ NPX := npx
 
 .PHONY: setup
 setup:
-	@$(NPM) install
+	@$(NPM) ci
 
 .PHONY: fmt-eslint
 fmt-eslint:

--- a/github/notifier/tsconfig.json
+++ b/github/notifier/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/github/subscriber/Makefile
+++ b/github/subscriber/Makefile
@@ -3,7 +3,7 @@ NPX := npx
 
 .PHONY: setup
 setup:
-	@$(NPM) install
+	@$(NPM) ci
 
 .PHONY: fmt-eslint
 fmt-eslint:

--- a/github/subscriber/tsconfig.json
+++ b/github/subscriber/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./"
+    "rootDir": "."
   },
   "include": [
-    "./**/*.ts"
+    "*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/hatebu/notifier/Makefile
+++ b/hatebu/notifier/Makefile
@@ -3,7 +3,7 @@ NPX := npx
 
 .PHONY: setup
 setup:
-	@$(NPM) install
+	@$(NPM) ci
 
 .PHONY: fmt-eslint
 fmt-eslint:

--- a/hatebu/notifier/tsconfig.json
+++ b/hatebu/notifier/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/hatebu/subscriber/Makefile
+++ b/hatebu/subscriber/Makefile
@@ -3,7 +3,7 @@ NPX := npx
 
 .PHONY: setup
 setup:
-	@$(NPM) install
+	@$(NPM) ci
 
 .PHONY: fmt-eslint
 fmt-eslint:

--- a/hatebu/subscriber/tsconfig.json
+++ b/hatebu/subscriber/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./"
+    "rootDir": "."
   },
   "include": [
-    "./**/*.ts"
+    "*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,15 +1,16 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "NodeNext",
     "lib": ["ES2020"],
+    "types": ["node"],
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,8 +2,12 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "NodeNext",
-    "lib": ["ES2020"],
-    "types": ["node"],
+    "lib": [
+      "ES2020"
+    ],
+    "types": [
+      "node"
+    ],
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Summary

PR #219 (typescript 5.9.3 → 6.0.3) を rebase 後に CI が通るための事前整備と、関連する設定ファイルの整理。

- chore: tsconfig.base.json で moduleResolution を node から nodenext に移行（TS 7.0 で廃止予定の node10 設定からの脱却、整合のため module も NodeNext に変更、TS 6 で自動取り込みされなくなる @types/node を明示）
- style: tsconfig 群の単一要素配列を複数行に統一（subscriber 側の既存スタイルと Emacs json-ts-mode の自動整形に合わせる）
- refactor: subscriber 系 tsconfig.json を notifier 系に揃える（rootDir / include 統一、効果のない outDir 削除）
- build: make setup を npm ci に切り替え（npm install による意図しないロックファイル書き戻しを解消、CI で推奨される install 方式と一致）

## Test plan

- [x] make lint が 4 サブディレクトリすべてで通る（TypeScript 5.9.3）
- [x] make setup でロックファイルに差分が出ない
- [x] GitHub Actions の test workflow が green
- [x] マージ後、PR #219 を rebase して CI が通ることを確認