### PR TITLE
chore: AWS の一時クレデンシャルの露出範囲を必要な step だけに狭める

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Configure AWS Credentials
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: ap-northeast-1
           role-duration-seconds: 900
           role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
+          output-credentials: true # 認証情報を step outputs として出力する
+          output-env-credentials: false # 認証情報を環境変数に出力せず、露出範囲を必要な step だけに狭める
       - run: make deploy
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
           GH_FEED_URL: ${{ secrets.GH_FEED_URL }}
           GH_TITLE_IGNORE_REGEXP: ${{ secrets.GH_TITLE_IGNORE_REGEXP }}
           GH_URL_IGNORE_REGEXP: ${{ secrets.GH_URL_IGNORE_REGEXP }}


### PR DESCRIPTION
- closes #243

`aws-actions/configure-aws-credentials` はデフォルトで一時クレデンシャルを環境変数に書き出すため、同一 job 内の後続 step すべてから参照できてしまう。

`output-env-credentials: false` で環境変数への書き出しを抑止し、`output-credentials: true` で得た step outputs を、実際に AWS を使う `make deploy` の step にだけ env で渡すようにした。

## AWS_REGION について

issue で「`AWS_REGION` / `AWS_DEFAULT_REGION` も出なくなるので渡し忘れないこと」と書いた点だが、今回は**あえて渡していない**。

懸念としては、`make deploy` が `sam validate` → `sam build` → `sam deploy` の順に実行するところ。samconfig.toml の `region` は `[default.deploy.parameters]` の下にあり、SAM の設定ファイルはコマンドごとにセクションが分かれるため `sam validate` には効かない。`sam validate` は `--lint` なしだと内部で `boto3.client("iam")` を作るのでリージョンを要求する。

とはいえ個人環境なので、まずはこのままデプロイして実際にエラーになるか確かめる。落ちたら `AWS_REGION` を env で渡すか、samconfig.toml の `region` を `[default.global.parameters]` に移して対応する。
