### PR TITLE
chore: sam validate がリージョンを解決できず Deploy が失敗する問題を解消する

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,11 +1,12 @@
 version = 0.1
 [default]
+[default.global.parameters]
+region = "ap-northeast-1"
 [default.deploy]
 [default.deploy.parameters]
 stack_name = "masutaka-feed"
 s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-494o19nbkn1d"
 s3_prefix = "masutaka-feed"
-region = "ap-northeast-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = "GitHubFeedUrl=\"\" GithubTitleIgnoreRegexp=\"\" GithubUrlIgnoreRegexp=\"\" GithubTitlePushoverRegexp=\"\" HatebuFeedUrl=\"\" PushoverAppToken=\"\" PushoverUserKey=\"\" MastodonUrl=\"\" MastodonAccessToken=\"\""

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,7 +1,9 @@
 version = 0.1
+
 [default]
 [default.global.parameters]
 region = "ap-northeast-1"
+
 [default.deploy]
 [default.deploy.parameters]
 stack_name = "masutaka-feed"


### PR DESCRIPTION
#245 で `output-env-credentials: false` にした結果、main の Deploy が失敗した。

```
Error: AWS Region was not found. Please configure your region through a profile or --region option
make: *** [Makefile:69: validate] Error 1
```

https://github.com/masutaka/masutaka-feed/actions/runs/30680388877

`make deploy` は `sam validate` → `sam build` → `sam deploy` の順に実行するが、`sam validate` は `--lint` なしだと内部で `boto3.client("iam")` を作るためリージョンを要求する。samconfig.toml の `region` は `[default.deploy.parameters]` の下にあり、SAM の設定ファイルはコマンドごとにセクションが分かれるため `sam validate` には効いていなかった。これまで通っていたのは configure-aws-credentials が `AWS_REGION` を環境変数に撒いていたおかげ。

`region` を `[default.global.parameters]` に移して全コマンドに効かせる。deploy.yml に `AWS_REGION` を足す案もあったが、リージョンの定義場所が samconfig.toml に一本化される方を選んだ。今後コマンドが増えても抜け漏れが起きない。

2 つ目のコミットは、ついでの空行整形。
