### PR TITLE
feat: ワークフロー検査に ghalint を追加する

### DIFF
--- a/.ghalint.yaml
+++ b/.ghalint.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/ghalint/refs/heads/main/json-schema/ghalint.json
+# ghalint - https://github.com/suzuki-shunsuke/ghalint
+
+excludes:
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    action_name: masutaka/actions/.github/workflows/*.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Configure AWS Credentials
         id: aws-credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  actionlint:
-    uses: masutaka/actions/.github/workflows/actionlint.yml@main
+  gh_action_lint:
+    uses: masutaka/actions/.github/workflows/gh_action_lint.yml@main
     permissions:
       contents: read
   codeql:
@@ -39,7 +39,7 @@ jobs:
   pushover:
     name: pushover if failure
     if: github.ref_name == github.event.repository.default_branch && failure()
-    needs: [actionlint, codeql, lint]
+    needs: [gh_action_lint, codeql, lint]
     uses: masutaka/actions/.github/workflows/pushover.yml@main
     permissions: {}
     secrets:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ graph TD
 ### Test Workflow
 - **Trigger**: Push to main branch, Pull Requests
 - **Actions**:
-  - actionlint: Validate GitHub Actions configuration
+  - gh_action_lint: Validate GitHub Actions workflows with actionlint and ghalint
   - CodeQL: Security vulnerability scanning
   - lint: TypeScript and ESLint static analysis (`make setup lint`)
   - Pushover notification on failure (main branch only)


### PR DESCRIPTION
## 概要

ワークフローの検査に [ghalint](https://github.com/suzuki-shunsuke/ghalint) を追加する。

masutaka/actions で actionlint と ghalint が `gh_action_lint.yml` に統合されたので、呼び出し側をそれに合わせて切り替えた。

- masutaka/actions#38

## 変更点

- `test.yml` の `actionlint` ジョブを `gh_action_lint` に置き換える
- `.ghalint.yaml` を追加し、自作 reusable workflow を `action_ref_should_be_full_length_commit_sha` の対象外にする
    - `.pinact.yaml` が `masutaka/.*` を `@main` のまま追従させる方針なので、それに揃えた
- 全ての `actions/checkout` に `persist-credentials: false` を設定する

## 補足

1 コミット目は ghalint が `checkout_persist_credentials_should_be_false` 違反を検知して意図的に失敗する。2 コミット目でそれを修正している。
